### PR TITLE
ESWE-452 - Switch to Ingress controller v1.2

### DIFF
--- a/helm_deploy/hmpps-education-employment-ui/Chart.yaml
+++ b/helm_deploy/hmpps-education-employment-ui/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-education-employment-ui
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 1.2.2
+    version: 2.1.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 0.4.1
+    version: 1.1.0
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-education-employment-ui/values.yaml
+++ b/helm_deploy/hmpps-education-employment-ui/values.yaml
@@ -10,6 +10,7 @@ generic-service:
     port: 3000
 
   ingress:
+    v1_2_enabled: true
     enabled: true
     host: app-hostname.local    # override per environment
     tlsSecretName: hmpps-education-employment-ui-cert


### PR DESCRIPTION
## What does this pull request do?
🔧 Enable ingress controller v1.2
🔧 Upgrade charts

## What is the intent behind these changes?
Cloud Platform will be carrying out the Kubernetes 1.22 upgrade from Tuesday 15th November.
Before this time, we must switch to Ingress controller v1.2.

Signed-off-by: theDustRoom <paul.massey@digital.justice.gov.uk>