### PR TITLE
ESWE-550_give_details_textbox_accessibility

### DIFF
--- a/server/views/pages/createProfile/jobOfParticularInterest/index.njk
+++ b/server/views/pages/createProfile/jobOfParticularInterest/index.njk
@@ -41,9 +41,9 @@
               value: jobOfParticularInterestDetails,
               type: "text",
               label: {
-                text: "Give details about a particular job",
-                classes: "govuk-label"
+                text: "Give details"
               },
+              attributes: { "aria-label" : "Give details of any job you are interested in" },
               errorMessage: errors.jobOfParticularInterestDetails
             }) }}
           {% endset -%}

--- a/server/views/pages/createProfile/jobOfParticularInterest/index.njk
+++ b/server/views/pages/createProfile/jobOfParticularInterest/index.njk
@@ -41,7 +41,8 @@
               value: jobOfParticularInterestDetails,
               type: "text",
               label: {
-                text: "Give details"
+                text: "Give details about a particular job",
+                classes: "govuk-label"
               },
               errorMessage: errors.jobOfParticularInterestDetails
             }) }}

--- a/server/views/pages/createProfile/supportDeclinedReason/index.njk
+++ b/server/views/pages/createProfile/supportDeclinedReason/index.njk
@@ -41,7 +41,8 @@
               value: supportDeclinedDetails,
               type: "text",
               label: {
-                text: "Give details"
+                text: "Give details why support is declined",
+                classes: "govuk-label"
               },
               errorMessage: errors.supportDeclinedDetails
             }) }}

--- a/server/views/pages/createProfile/supportDeclinedReason/index.njk
+++ b/server/views/pages/createProfile/supportDeclinedReason/index.njk
@@ -41,9 +41,9 @@
               value: supportDeclinedDetails,
               type: "text",
               label: {
-                text: "Give details why support is declined",
-                classes: "govuk-label"
+                text: "Give details"
               },
+              attributes: { "aria-label" : "Give details why support is declined" },
               errorMessage: errors.supportDeclinedDetails
             }) }}
           {% endset -%}

--- a/server/views/pages/createProfile/trainingAndQualifications/index.njk
+++ b/server/views/pages/createProfile/trainingAndQualifications/index.njk
@@ -41,8 +41,9 @@
               value: trainingAndQualificationsDetails,
               type: "text",
               label: {
-                text: "Give details"
-              },
+                    text: "Give details of qualifications or training",
+                    classes: "govuk-label"
+                },
               errorMessage: errors.trainingAndQualificationsDetails
             }) }}
           {% endset -%}

--- a/server/views/pages/createProfile/trainingAndQualifications/index.njk
+++ b/server/views/pages/createProfile/trainingAndQualifications/index.njk
@@ -41,9 +41,9 @@
               value: trainingAndQualificationsDetails,
               type: "text",
               label: {
-                    text: "Give details of qualifications or training",
-                    classes: "govuk-label"
-                },
+                text: "Give details"
+              },
+              attributes: { "aria-label" : "Give details of any qualifications or training" },
               errorMessage: errors.trainingAndQualificationsDetails
             }) }}
           {% endset -%}

--- a/server/views/pages/createProfile/typeOfWork/index.njk
+++ b/server/views/pages/createProfile/typeOfWork/index.njk
@@ -41,9 +41,9 @@
               value: typeOfWorkDetails,
               type: "text",
               label: {
-                text: "Give details of types of work",
-                classes: "govuk-label"
+                text: "Give details"
               },
+              attributes: { "aria-label" : "Give details of any work you are interested in" },
               errorMessage: errors.typeOfWorkDetails
             }) }}
           {% endset -%}

--- a/server/views/pages/createProfile/typeOfWork/index.njk
+++ b/server/views/pages/createProfile/typeOfWork/index.njk
@@ -41,7 +41,8 @@
               value: typeOfWorkDetails,
               type: "text",
               label: {
-                text: "Give details"
+                text: "Give details of types of work",
+                classes: "govuk-label"
               },
               errorMessage: errors.typeOfWorkDetails
             }) }}

--- a/server/views/pages/createProfile/whatNeedsToChange/index.njk
+++ b/server/views/pages/createProfile/whatNeedsToChange/index.njk
@@ -41,7 +41,8 @@
               value: whatNeedsToChangeDetails,
               type: "text",
               label: {
-                text: "Give details"
+                text: "Give details of change of circumstances",
+                classes: "govuk-label"
               },
               errorMessage: errors.whatNeedsToChangeDetails
             }) }}

--- a/server/views/pages/createProfile/whatNeedsToChange/index.njk
+++ b/server/views/pages/createProfile/whatNeedsToChange/index.njk
@@ -41,9 +41,9 @@
               value: whatNeedsToChangeDetails,
               type: "text",
               label: {
-                text: "Give details of change of circumstances",
-                classes: "govuk-label"
+                text: "Give details"
               },
+              attributes: { "aria-label" : "Give details of any change of circumstance" },
               errorMessage: errors.whatNeedsToChangeDetails
             }) }}
           {% endset -%}

--- a/server/views/pages/createProfile/workExperience/index.njk
+++ b/server/views/pages/createProfile/workExperience/index.njk
@@ -41,7 +41,8 @@
               value: workExperienceDetails,
               type: "text",
               label: {
-                text: "Give details"
+                text: "Give details of any previous experience",
+                classes: "govuk-label"
               },
               errorMessage: errors.workExperienceDetails
             }) }}

--- a/server/views/pages/createProfile/workExperience/index.njk
+++ b/server/views/pages/createProfile/workExperience/index.njk
@@ -41,9 +41,9 @@
               value: workExperienceDetails,
               type: "text",
               label: {
-                text: "Give details of any previous experience",
-                classes: "govuk-label"
+                text: "Give details"
               },
+              attributes: { "aria-label" : "Give details of any previous experience" },
               errorMessage: errors.workExperienceDetails
             }) }}
           {% endset -%}


### PR DESCRIPTION
Update textarea label as recommended by accessibility review:

- Updating the label for the text input field. This would explicitly state the purpose of the field for both sighted and screen reader users: <label class="govuk-label"> Give details about a particular job</label>

**Reviewers**
@gary-dutton-moj 