### PR TITLE
fix_cypress_ts_config fixed tsconfig

### DIFF
--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -5,8 +5,7 @@
     "lib": ["es5", "dom", "es2015.promise"],
     "types": ["cypress", "express", "express-session"],
     "esModuleInterop": true,
-    "skipLibCheck": true,
-    "typeRoots": ["../server/@types"]
+    "skipLibCheck": true
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
- Removing ts roots fixes errors and is not required