### PR TITLE
Fix npm version on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,8 @@ jobs:
       - checkout
       - run:
           name: Update npm
-          command: 'sudo npm install -g npm@latest'
+          # temporary hard code version until we move to v10
+          command: 'sudo npm install -g npm@9.8.1'
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:


### PR DESCRIPTION
👷 Use latest version 9 of npm

NPM 10 is causing issues with builds, CircleCI config is set to install the latest version so must be changed to specify version 9.