### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.2.1
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.12.1
 
 parameters:
@@ -48,7 +48,8 @@ jobs:
             export BUILD_NUMBER=${DATE}.${CIRCLE_BUILD_NUM}
             export GIT_REF="$CIRCLE_SHA1"
             npm run record-build-info
-      - run: # Run linter after build because the integration test code depend on compiled typescript...
+      - run:
+          # Run linter after build because the integration test code depend on compiled typescript...
           name: Linter check
           command: npm run lint
       - persist_to_workspace:

--- a/helm_deploy/hmpps-education-employment-ui/Chart.yaml
+++ b/helm_deploy/hmpps-education-employment-ui/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-education-employment-ui
 version: 1.0.0
 dependencies:
   - name: generic-service
-    version: 2.6.5
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/hmpps-education-employment-ui/values.yaml
+++ b/helm_deploy/hmpps-education-employment-ui/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-education-employment-ui
 
@@ -6,14 +5,14 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-education-employment-ui
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
     v1_2_enabled: true
     v0_47_enabled: false
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-education-employment-ui-cert
 
   livenessProbe:
@@ -57,99 +56,16 @@ generic-service:
       REDIS_AUTH_TOKEN: "auth_token"
 
   allowlist:
-    office: "217.33.148.210/32"
-    quantum: "62.25.109.197/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    quantum_alt: "212.137.36.230/32"
-    health-kick: "35.177.252.195/32"
-    digitalprisons1: "52.56.112.98/32"
-    digitalprisons2: "52.56.118.154/32"
-    mojvpn: "81.134.202.29/32"
-    j5-phones-1: "35.177.125.252/32"
-    j5-phones-2: "35.177.137.160/32"
-    sodexo-northumberland: "88.98.48.10/32"
-    sodexo-northumberland2: "51.148.47.137/32"
-    sodoxeo-forest-bank: "51.155.85.249/32"
-    sodexo-peterborough: "51.155.55.241/32"
-    serco: "217.22.14.0/24"
-    ark-nps-hmcts-ttp1: "195.59.75.0/24"
-    ark-nps-hmcts-ttp2: "194.33.192.0/25"
-    ark-nps-hmcts-ttp3: "194.33.193.0/25"
-    ark-nps-hmcts-ttp4: "194.33.196.0/25"
-    ark-nps-hmcts-ttp5: "194.33.197.0/25"
-    oakwood-01: "217.161.76.184/29"
-    oakwood-02: "217.161.76.192/29"
-    oakwood-1: "217.161.76.187/32"
-    oakwood-2: "217.161.76.195/32"
-    oakwood-3: "217.161.76.186/32"
-    oakwood-4: "217.161.76.194/32"
-    durham-tees-valley: "51.179.197.1/32"
-    interservfls: "51.179.196.131/32"
-    sodexo1: "80.86.46.16/32"
-    sodexo2: "80.86.46.17/32"
-    sodexo3: "80.86.46.18/32"
-    sodexo4: "51.148.9.201"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    dxc_webproxy1: "195.92.38.20/32"
-    dxc_webproxy2: "195.92.38.21/32"
-    dxc_webproxy3: "195.92.38.22/32"
-    dxc_webprox23: "195.92.38.23/32"
-    moj-official-tgw-prod: "51.149.250.0/24"
-    moj-official-tgw-preprod: "51.149.251.0/24"
-    crc-rrp: "62.253.83.37/32"
-    crc-pp-wwm: "5.153.255.210/32"
-    moj-official-ark-c-expo-e: "51.149.249.0/29"
-    moj-official-ark-c-vodafone: "194.33.248.0/29"
-    moj-official-ark-f-vodafone: "194.33.249.0/29"
-    moj-official-ark-f-expo-e: "51.149.249.32/29"
-    met-police-talktalk-vpn-1: "212.139.143.66/32"
-    met-police-talktalk-vpn-2: "212.74.97.221/32"
-    met-police-vodafone-1: "195.27.18.79/32"
-    met-police-vodafone-2: "195.27.18.110/32"
-    met-police-vodafone-3: "195.80.67.207/32"
-    police-1: "81.144.174.115/32"
-    police-2: "81.144.241.238/32"
-    police-3: "62.252.202.50/32"
-    police-4-1: "80.194.71.100/32"
-    police-4-2: "82.33.248.165/32"
-    police-5: "52.56.62.0/24"
-    police-6: "80.193.134.32/32"
-    police-7: "195.92.38.21/32"
-    police-8: "80.193.128.200/32"
-    police-9: "194.73.161.50/32"
-    police-10: "165.225.81.49/32"
-    police-11: "195.89.175.213/32"
-    police-12: "195.89.175.229/32"
-    police-northants-1: "212.250.136.96/27"
-    police-northants-2: "213.106.80.32/27"
-    police-west-york-1: "195.188.22.0/27"
-    police-west-york-2: "195.188.22.128/27"
-    police-west-york-3: "195.89.14.37"
-    police-west-york-4: "195.27.188.37"
-    police-south-york-public: "80.193.114.10"
-    police-south-york-mossway: "51.231.157.126"
-    police-south-york-atlas: "51.231.157.222"
-    police-humberside-public: "80.100.176.162"
-    police-humberside-priory: "51.231.157.226"
-    sscl-blackpool: "31.121.5.27"
-    sscl-azure: "51.142.106.199"
-    sscl-york: "62.6.61.29"
-    sscl-newcastle: "62.172.79.105"
-    sscl-newport: "217.38.237.212"
-    fivewells-1: "195.89.157.56/29"
-    fivewells-2: "195.59.215.184/29"
-    fivewells-3: "51.149.250.0/24"
-    fivewells-4: "51.149.249.0/29"
-    fivewells-5: "194.33.249.0/29"
-    fivewells-6: "51.149.249.32/29"
-    fivewells-7: "194.33.248.0/29"
-    mojo-azure-landing-zone-public-egress-1: "20.49.214.199/32"
-    mojo-azure-landing-zone-public-egress-2: "20.49.214.228/32"
-    mojo-azure-landing-zone-public-egress-3: "20.26.11.71/32"
-    mojo-azure-landing-zone-public-egress-4: "20.26.11.108/32"
+    sscl-blackpool: 31.121.5.27/32
+    sscl-azure: 51.142.106.199/32
+    sscl-york: 62.6.61.29/32
+    sscl-newcastle: 62.172.79.105/32
+    sscl-newport: 217.38.237.212/32
+    groups:
+      - internal
+      - prisons
+      - private_prisons
+      - police
 
 generic-prometheus-alerts:
   targetApplication: hmpps-education-employment-ui


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-education-employment-ui/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons,private_prisons,police`
- The size of the allowlist defined in this file will change: `87 => 5 (82 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- police-nottinghamshire-1
  

- police-nottinghamshire-2
  

- police-nottinghamshire-3
  

- police-nottinghamshire-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- quantum
  

- quantum_alt
  

- health-kick
  

- digitalprisons1
  

- digitalprisons2
  

- j5-phones-1
  

- j5-phones-2
  

- durham-tees-valley
  

- interservfls
  

- dxc_webproxy1
  

- dxc_webproxy2
  

- dxc_webproxy3
  

- dxc_webprox23
  

- crc-rrp
  

- crc-pp-wwm
  
