### PR TITLE
Add prison education ip ranges

### DIFF
--- a/helm_deploy/hmpps-education-employment-ui/values.yaml
+++ b/helm_deploy/hmpps-education-employment-ui/values.yaml
@@ -60,6 +60,7 @@ generic-service:
       - internal
       - prisons
       - private_prisons
+      - prisons-education
 
 generic-prometheus-alerts:
   targetApplication: hmpps-education-employment-ui


### PR DESCRIPTION
IP range for the new prison education networks that have been and are being installed by HMPPS.
They are replacing the networks that existed before which were installed and managed by the education providers themselves, now the networks are being brought in house.