### PR TITLE
ESWE-1309: fix table sort indicators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ministryofjustice/frontend": "^5.1.2",
+        "@ministryofjustice/frontend": "^5.1.0",
         "@ministryofjustice/hmpps-connect-dps-components": "^2.1.0",
         "@types/express-serve-static-core": "^4.19.5",
         "@types/qs": "^6.9.18",
@@ -32,6 +32,7 @@
         "express": "^4.21.1",
         "express-session": "^1.18.0",
         "follow-redirects": "^1.15.9",
+        "formidable": "^3.5.4",
         "govuk-frontend": "^5.9.0",
         "helmet": "^7.1.0",
         "http-errors": "^2.0.0",
@@ -1431,9 +1432,9 @@
       "license": "MIT"
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-5.1.2.tgz",
-      "integrity": "sha512-ZpxmefOMLdm4CQGctz4KLIlbgJGHTjhJXohKAygZoA+/pP+paGmbeGIDkdjW7wRF5etld+ERZ9yqNeoMmm+VAw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-5.1.0.tgz",
+      "integrity": "sha512-rgvKBJcloW+Uzn7bEAjPMhyUUpxWWFGU58vQsj8Cm6c63fk0gm8UCYVYl0C97W5jgbSWv7gK2+tIQDdHzG1Hcg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
@@ -1453,29 +1454,6 @@
         "@types/nunjucks": "^3.2.6",
         "nunjucks": "^3.2.4",
         "superagent": "^9.0.2"
-      }
-    },
-    "node_modules/@ministryofjustice/hmpps-connect-dps-components/node_modules/formidable": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
-      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
-      "license": "MIT",
-      "dependencies": {
-        "dezalgo": "^1.0.4",
-        "hexoid": "^2.0.0",
-        "once": "^1.4.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
-    "node_modules/@ministryofjustice/hmpps-connect-dps-components/node_modules/hexoid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
-      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@ministryofjustice/hmpps-connect-dps-components/node_modules/mime": {
@@ -1508,6 +1486,18 @@
       },
       "engines": {
         "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1668,6 +1658,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -6072,14 +6071,17 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "license": "MIT",
       "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-        "hexoid": "^1.0.0",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -6530,14 +6532,6 @@
       "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/hexoid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
-      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/html-escaper": {
@@ -11009,6 +11003,21 @@
         "node": ">=6.4.0 <13 || >=14"
       }
     },
+    "node_modules/superagent/node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
     "node_modules/superagent/node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -11031,31 +11040,6 @@
       },
       "engines": {
         "node": ">=14.18.0"
-      }
-    },
-    "node_modules/supertest/node_modules/formidable": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
-      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dezalgo": "^1.0.4",
-        "hexoid": "^2.0.0",
-        "once": "^1.4.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
-    "node_modules/supertest/node_modules/hexoid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
-      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/supertest/node_modules/mime": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     ]
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "^5.1.2",
+    "@ministryofjustice/frontend": "^5.1.0",
     "@ministryofjustice/hmpps-connect-dps-components": "^2.1.0",
     "@types/express-serve-static-core": "^4.19.5",
     "@types/qs": "^6.9.18",
@@ -118,6 +118,7 @@
     "express": "^4.21.1",
     "express-session": "^1.18.0",
     "follow-redirects": "^1.15.9",
+    "formidable": "^3.5.4",
     "govuk-frontend": "^5.9.0",
     "helmet": "^7.1.0",
     "http-errors": "^2.0.0",


### PR DESCRIPTION
This PR entails regressing govuk-frontend to 5.1.0 as the new 5.1.2 has a patch that is affecting the display of the sort indicators.

| Package | Change |
|---|---|
| [@ministryofjustice/frontend](https://redirect.github.com/ministryofjustice/moj-frontend) | [`^5.1.2` -> `5.1.0`]
| [formidable](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-education-employment-ui/1863/workflows/fcbd3f21-c4d5-4ac9-8e72-0bffb6e1ea2b/jobs/7695) | [`2.1.2` -> `3.5.4`]


<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/ministryofjustice/moj-frontend/releases"><code>@​ministryofjustice/frontend</code>'s releases</a>.</em></p>
<blockquote>

<h2>v5.1.0</h2>
<h1><a href="https://github.com/ministryofjustice/moj-frontend/compare/v5.0.0...v5.1.0">5.1.0</a> (2025-04-07)</h1>
<p>This is a major release that changes the code of every JavaScript component. There are breaking changes to 8 building blocks.</p>
<h2>Main changes</h2>
<h3>Removed jQuery dependency</h3>
<p>In this release we’ve updated all our components to no longer require jQuery. This means jQuery is no longer a dependency of MoJ Frontend. You can remove jQuery from your service if you have no other code that needs it.</p>
<h3>Import MoJ Frontend JavaScript as ECMAScript (ES) modules</h3>
<p>You can now import our component JavaScript into your service as ES modules, if you're using a bundler.</p>
<p>This change allows you to import only the JavaScript you need, and helps reduce duplication of polyfills.</p>
<p>Because we're shipping ES modules in addition to how we currently publish our component JavaScript, this change is backwards compatible. This is optional.</p>
<p>If you want to import using ES modules, we recommend you only use <code>import</code> to import the JavaScript for components you're using in your service.</p>