### PR TITLE
Eswe 1160 add prisonid to profile ** DO NOT MERGE **

### DIFF
--- a/server/data/models/createProfileRequest.ts
+++ b/server/data/models/createProfileRequest.ts
@@ -17,6 +17,7 @@ export default class CreateProfileRequest {
     this.profileData = {
       status: data.status,
       prisonName: data.prisonName,
+      prisonId: data.prisonId,
       supportDeclined:
         data.supportOptIn === YesNoValue.NO
           ? {

--- a/server/data/models/editProfileRequest.ts
+++ b/server/data/models/editProfileRequest.ts
@@ -17,6 +17,7 @@ export default class EditProfileRequest {
     this.profileData = {
       status: data.status,
       prisonName: data.prisonName,
+      prisonId: data.prisonId,
       supportDeclined: this.buildSupportDeclined(data),
       supportAccepted: this.buildSupportAccepted(data, existingProfile),
     }

--- a/server/data/prisonerProfile/interfaces/createProfileRequestArgs.ts
+++ b/server/data/prisonerProfile/interfaces/createProfileRequestArgs.ts
@@ -17,6 +17,7 @@ export default interface CreateProfileRequestArgs {
   supportOptIn?: YesNoValue
   rightToWork?: YesNoValue
   prisonName?: string
+  prisonId?: string
 
   // Support declined fields
   supportDeclinedReason?: SupportDeclinedReasonValue[]

--- a/server/data/prisonerProfile/interfaces/prisonerProfile.ts
+++ b/server/data/prisonerProfile/interfaces/prisonerProfile.ts
@@ -14,6 +14,7 @@ export default interface PrisonerProfile {
   profileData: {
     status: ProfileStatus
     prisonName?: string
+    prisonId?: string
 
     supportDeclined?: {
       modifiedBy: string

--- a/server/data/prisonerProfile/interfaces/profileDataSection.ts
+++ b/server/data/prisonerProfile/interfaces/profileDataSection.ts
@@ -7,6 +7,8 @@ export default interface ProfileDataSection {
 
   prisonName?: string
 
+  prisonId?: string
+
   supportDeclined?: SupportDeclinedSection
 
   supportAccepted?: SupportAcceptedSection

--- a/server/data/prisonerProfile/interfaces/updatePrisonerProfile.ts
+++ b/server/data/prisonerProfile/interfaces/updatePrisonerProfile.ts
@@ -6,6 +6,7 @@ export default interface UpdatePrisonerProfile {
   profileData: {
     status: string
     prisonName?: string
+    prisonId?: string
 
     supportDeclined?: {
       modifiedBy: string

--- a/server/routes/workReadiness/createProfile/checkYourAnswers/checkYourAnswersController.test.ts
+++ b/server/routes/workReadiness/createProfile/checkYourAnswers/checkYourAnswersController.test.ts
@@ -75,7 +75,7 @@ describe('CheckYourAnswersController', () => {
       expect(next).toHaveBeenCalledTimes(1)
       expect(res.render).toHaveBeenCalledTimes(0)
     })
-    it('On success - Calls create profile, tidy session and redirects to workProfile', async () => {
+    it('On success - Calls createProfile, tidy session and redirects to workProfile', async () => {
       mockService.createProfile.mockResolvedValue({})
 
       await controller.post(req, res, next)
@@ -83,6 +83,61 @@ describe('CheckYourAnswersController', () => {
       // expect(mockService.createProfile).toHaveBeenCalledTimes(1)
       expect(res.redirect).toHaveBeenCalledTimes(1)
       expect(getSessionData(req, ['createProfile', id])).toBeFalsy()
+    })
+
+    it('On success - Calls createProfile with prisonId included in data', async () => {
+      const mockPrisonId = 'MOCK_PRISON_ID'
+      const mockToken = 'MOCK_TOKEN'
+      const bookingId = 123456
+      const prisonName = 'Mock Prison'
+
+      // Set up required mock context
+      res.locals.user = { username: 'USER1', token: mockToken }
+
+      req.context.prisoner = {
+        bookingId,
+        prisonId: mockPrisonId,
+        prisonName,
+      }
+
+      // Set up required session data
+      setSessionData(req, ['createProfile', id], {
+        prisoner: req.context.prisoner,
+        record: {
+          abilityToWork: 'YES',
+          manageDrugsAndAlcohol: 'YES',
+          alreadyInPlace: 'NONE',
+          identification: 'ID',
+          typeOfIdentificationDetails: '',
+          rightToWork: 'NO',
+          supportOptIn: 'NO',
+          supportDeclinedReason: 'OTHER',
+          supportDeclinedDetails: '',
+          whatNeedsToChange: 'ATTITUDE',
+          whatNeedsToChangeDetails: '',
+          typeOfWork: ['TECH'],
+          typeOfWorkDetails: '',
+          jobOfParticularInterest: 'NO',
+          jobOfParticularInterestDetails: '',
+          workExperience: 'SOME',
+          workExperienceDetails: '',
+          trainingAndQualifications: 'YES',
+          trainingAndQualificationsDetails: '',
+        },
+        statusChange: false,
+      })
+
+      mockService.createProfile.mockResolvedValue({})
+
+      await controller.post(req, res, next)
+
+      // Check prisonId is included in second argument
+      expect(mockService.createProfile).toHaveBeenCalledWith(
+        mockToken,
+        expect.objectContaining({
+          prisonId: mockPrisonId,
+        }),
+      )
     })
   })
 })

--- a/server/routes/workReadiness/createProfile/checkYourAnswers/checkYourAnswersController.ts
+++ b/server/routes/workReadiness/createProfile/checkYourAnswers/checkYourAnswersController.ts
@@ -69,6 +69,7 @@ export default class CheckYourAnswersController {
         trainingAndQualifications: record.trainingAndQualifications,
         trainingAndQualificationsDetails: record.trainingAndQualificationsDetails,
         prisonName: prisoner.prisonName,
+        prisonId: prisoner.prisonId,
       }
 
       if (statusChange) {


### PR DESCRIPTION
This PR captures the prison identifier (the Prison ID), which is needed for reporting; Dashboard reporting metrics are presented per prison, and thus Prison ID is necessary to report such numbers precisely.