### PR TITLE
ESWE-1160 fix missing prisonId issue when updating profile

### DIFF
--- a/server/data/models/updateProfileRequest.ts
+++ b/server/data/models/updateProfileRequest.ts
@@ -9,6 +9,7 @@ export default class UpdateProfileRequest {
       status: profile.profileData.status,
       supportDeclined: profile.profileData.supportDeclined,
       supportAccepted: profile.profileData.supportAccepted,
+      prisonId: profile.profileData.prisonId,
       within12Weeks: profile.profileData.within12Weeks,
     }
   }

--- a/server/routes/workReadiness/changeStatus/newStatus/newStatusController.ts
+++ b/server/routes/workReadiness/changeStatus/newStatus/newStatusController.ts
@@ -99,6 +99,7 @@ export default class NewStatusController {
               bookingId: prisoner.bookingId,
               status: newStatus,
               currentUser: res.locals.user.username,
+              prisonId: prisoner.prisonId,
             },
             profile,
           ),


### PR DESCRIPTION
fix the issue of `missing prisonId` when updating profile, for
1. Update action's status
2. Change profile status