### PR TITLE
ESWE-1318 fix `within12Weeks` flag

### DIFF
--- a/server/data/models/createProfileRequest.ts
+++ b/server/data/models/createProfileRequest.ts
@@ -18,6 +18,7 @@ export default class CreateProfileRequest {
       status: data.status,
       prisonName: data.prisonName,
       prisonId: data.prisonId,
+      within12Weeks: data.within12Weeks,
       supportDeclined:
         data.supportOptIn === YesNoValue.NO
           ? {

--- a/server/routes/workReadiness/actions/editAction/editActionController.ts
+++ b/server/routes/workReadiness/actions/editAction/editActionController.ts
@@ -143,7 +143,8 @@ export default class EditActionController {
       }
 
       // Indicate whether releaseDate is within 12 weeks or not
-      profile.profileData.within12Weeks = isWithin12Weeks(profile.profileData.nonDtoReleaseDate)
+      profile.profileData.within12Weeks = isWithin12Weeks(data.prisoner.nonDtoReleaseDate)
+      profile.profileData.prisonId = data.prisoner.prisonId
 
       deleteSessionData(req, ['editAction', id, 'cachedValues'])
 

--- a/server/routes/workReadiness/changeStatus/newStatus/newStatusController.ts
+++ b/server/routes/workReadiness/changeStatus/newStatus/newStatusController.ts
@@ -86,6 +86,7 @@ export default class NewStatusController {
 
       // Indicate whether releaseDate is within 12 weeks or not
       profile.profileData.within12Weeks = isWithin12Weeks(prisoner.nonDtoReleaseDate)
+      profile.profileData.prisonId = prisoner.prisonId
 
       // Status only change
       if (this.isStatusOnlyChange(newStatus, profile.profileData.status, profile)) {

--- a/server/routes/workReadiness/createProfile/abilityToWork/abilityToWorkController.ts
+++ b/server/routes/workReadiness/createProfile/abilityToWork/abilityToWorkController.ts
@@ -98,7 +98,8 @@ export default class AbilityToWorkController {
         }
 
         // Indicate whether releaseDate is within 12 weeks or not
-        profile.profileData.within12Weeks = isWithin12Weeks(profile.profileData.nonDtoReleaseDate)
+        profile.profileData.within12Weeks = isWithin12Weeks(data.prisoner.nonDtoReleaseDate)
+        profile.profileData.prisonId = data.prisoner.prisonId
 
         // Call api, change status
         await this.prisonerProfileService.updateProfile(res.locals.user.token, id, new UpdateProfileRequest(profile))

--- a/server/routes/workReadiness/createProfile/ineligableToWork/ineligableToWorkController.ts
+++ b/server/routes/workReadiness/createProfile/ineligableToWork/ineligableToWorkController.ts
@@ -8,6 +8,7 @@ import addressLookup from '../../../addressLookup'
 import { deleteSessionData, getSessionData } from '../../../../utils/session'
 import PrisonerViewModel from '../../../../viewModels/prisonerViewModel'
 import pageTitleLookup from '../../../../utils/pageTitleLookup'
+import isWithin12Weeks from '../../../../utils/isWithin12Weeks'
 
 export default class IneligableToWorkController {
   constructor(private readonly prisonerProfileService: PrisonerProfileService) {}
@@ -51,6 +52,8 @@ export default class IneligableToWorkController {
         prisonerId: id,
         bookingId: prisoner.bookingId,
         status: ProfileStatus.NO_RIGHT_TO_WORK,
+        prisonId: prisoner.prisonId,
+        within12Weeks: isWithin12Weeks(prisoner.nonDtoReleaseDate),
         currentUser: res.locals.user.username,
       })
 

--- a/server/routes/workReadiness/createProfile/jobOfParticularInterest/jobOfParticularInterestController.ts
+++ b/server/routes/workReadiness/createProfile/jobOfParticularInterest/jobOfParticularInterestController.ts
@@ -98,7 +98,8 @@ export default class JobOfParticularInterestController {
         }
 
         // Indicate whether releaseDate is within 12 weeks or not
-        profile.profileData.within12Weeks = isWithin12Weeks(data.prisoner.releaseDate)
+        profile.profileData.within12Weeks = isWithin12Weeks(data.prisoner.nonDtoReleaseDate)
+        profile.profileData.prisonId = data.prisoner.prisonId
 
         // Call api, change status
         await this.prisonerProfileService.updateProfile(res.locals.user.token, id, new UpdateProfileRequest(profile))

--- a/server/routes/workReadiness/createProfile/trainingAndQualifications/trainingAndQualificationsController.ts
+++ b/server/routes/workReadiness/createProfile/trainingAndQualifications/trainingAndQualificationsController.ts
@@ -12,6 +12,7 @@ import PrisonerProfileService from '../../../../services/prisonerProfileService'
 import UpdateProfileRequest from '../../../../data/models/updateProfileRequest'
 import workProfileTabs from '../../../../enums/workProfileTabs'
 import pageTitleLookup from '../../../../utils/pageTitleLookup'
+import isWithin12Weeks from '../../../../utils/isWithin12Weeks'
 
 export default class TrainingAndQualificationsController {
   constructor(private readonly prisonerProfileService: PrisonerProfileService) {}
@@ -97,6 +98,10 @@ export default class TrainingAndQualificationsController {
             ? trainingAndQualificationsDetails
             : '',
         }
+
+        // Indicate whether releaseDate is within 12 weeks or not
+        profile.profileData.within12Weeks = isWithin12Weeks(data.prisoner.nonDtoReleaseDate)
+        profile.profileData.prisonId = data.prisoner.prisonId
 
         // Call api, change status
         await this.prisonerProfileService.updateProfile(res.locals.user.token, id, new UpdateProfileRequest(profile))

--- a/server/routes/workReadiness/createProfile/typeOfWork/typeOfWorkController.ts
+++ b/server/routes/workReadiness/createProfile/typeOfWork/typeOfWorkController.ts
@@ -101,7 +101,8 @@ export default class TypeOfWorkController {
         }
 
         // Indicate whether releaseDate is within 12 weeks or not
-        profile.profileData.within12Weeks = isWithin12Weeks(profile.profileData.nonDtoReleaseDate)
+        profile.profileData.within12Weeks = isWithin12Weeks(data.prisoner.nonDtoReleaseDate)
+        profile.profileData.prisonId = data.prisoner.prisonId
 
         // Call api, change status
         await this.prisonerProfileService.updateProfile(res.locals.user.token, id, new UpdateProfileRequest(profile))

--- a/server/routes/workReadiness/createProfile/workExperience/workExperienceController.ts
+++ b/server/routes/workReadiness/createProfile/workExperience/workExperienceController.ts
@@ -100,7 +100,8 @@ export default class WorkExperienceController {
         }
 
         // Indicate whether releaseDate is within 12 weeks or not
-        profile.profileData.within12Weeks = isWithin12Weeks(data.prisoner.releaseDate)
+        profile.profileData.within12Weeks = isWithin12Weeks(data.prisoner.nonDtoReleaseDate)
+        profile.profileData.prisonId = data.prisoner.prisonId
 
         // Call api, change status
         await this.prisonerProfileService.updateProfile(res.locals.user.token, id, new UpdateProfileRequest(profile))

--- a/server/viewModels/prisonerViewModel.ts
+++ b/server/viewModels/prisonerViewModel.ts
@@ -128,6 +128,9 @@ export default class PrisonerViewModel {
 
   additionalDaysAwarded: number
 
+  @Type(() => Date)
+  @Expose()
+  @Transform(formatDateStringToddMMMyyyy)
   nonDtoReleaseDate: string
 
   @Expose()


### PR DESCRIPTION
Fixes for
1) create profile with no right to work (missing prison ID, within 12 weeks flag)
2) update profile with wrong/inconsistent release dates (`nonDtoReleaseDate` over `releaseDate`)
3) update both  (prison ID, within 12 weeks flag) when updating training and qualifications