### PR TITLE
ESWE-1355: suppress out-of-hours alerts

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -44,7 +44,11 @@ generic-service:
     RANDOM_POSTCODES_IN_DEV: true
     USE_COMPONENT_FALLBACKS: true
 
+  scheduledDowntime:
+    enabled: true
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
+  businessHoursOnly: true
   alertSeverity: education-alerts-non-prod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -42,7 +42,11 @@ generic-service:
     REPORTING_LINK_ENABLED: false
     USE_COMPONENT_FALLBACKS: true
 
+  scheduledDowntime:
+    enabled: true
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
+  businessHoursOnly: true
   alertSeverity: education-alerts-non-prod


### PR DESCRIPTION
This PR is to stop certain nginx-5xx errors that occur overnight, such as the following pinging services:

- GET /health/**
- GET /health
- GET /info 