### PR TITLE
ESWE-1361: Display special characters correctly

### DIFF
--- a/server/views/pages/candidateMatching/jobDetails/index.njk
+++ b/server/views/pages/candidateMatching/jobDetails/index.njk
@@ -97,7 +97,7 @@
         Essential criteria
       </h2>
       <p class="govuk-body" id="essentialCriteria">
-        {{ job.essentialCriteria | striptags(true) | escape | nl2br }}
+        {{ job.essentialCriteria | striptags(true) | safe | nl2br }}
       </p>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
@@ -107,7 +107,7 @@
       </h2>
       <p class="govuk-body" id="desirableCriteria">
         {% if job.desirableCriteria %}
-          {{ job.desirableCriteria | striptags(true) | escape | nl2br }}
+          {{ job.desirableCriteria | striptags(true) | safe | nl2br }}
         {% else %}
           Not provided
         {% endif%}
@@ -119,7 +119,7 @@
         Job description
       </h2>
       <p class="govuk-body" id="description">
-        {{ job.description | striptags(true) | escape | nl2br }}
+        {{ job.description | striptags(true) | safe | nl2br }}
       </p>
 
       {% include './partials/_jobDetailsFormControls.njk' %}

--- a/server/views/pages/candidateMatching/manageApplication/index.njk
+++ b/server/views/pages/candidateMatching/manageApplication/index.njk
@@ -45,7 +45,7 @@
               </div>
           </div>
 
-          <p class="govuk-body govuk-!-margin-bottom-1" data-qa="how-to-apply">How to apply: {{ job.howToApply }}</p>
+          <p class="govuk-body govuk-!-margin-bottom-1" data-qa="how-to-apply">How to apply: {{ job.howToApply | safe }}</p>
         </div>
 
         {% include './partials/_applicationHistory.njk' %}

--- a/server/views/pages/workProfile/partials/_supportDeclinedSection.njk
+++ b/server/views/pages/workProfile/partials/_supportDeclinedSection.njk
@@ -4,7 +4,7 @@
   </dt>
   <dd class="govuk-summary-list__value" data-qa="overview-declined-reason">
     {% for item in profile.profileData.supportDeclined.supportToWorkDeclinedReason %}
-      <div>{{ contentLookup.fields.supportDeclinedReason[item] }}{{ ' - ' +  profile.profileData.supportDeclined.supportToWorkDeclinedReasonOther if item === 'OTHER' }}{{ ',' if profile.profileData.supportDeclined.supportToWorkDeclinedReason.length !== loop.index }}</div>
+      <div>{{ contentLookup.fields.supportDeclinedReason[item] }}{{ (' - ' +  profile.profileData.supportDeclined.supportToWorkDeclinedReasonOther if item === 'OTHER') | safe }}{{ ',' if profile.profileData.supportDeclined.supportToWorkDeclinedReason.length !== loop.index }}</div>
     {% endfor %}
   </dd>
   <dd class="govuk-summary-list__actions">
@@ -19,7 +19,7 @@
   </dt>
   <dd class="govuk-summary-list__value" data-qa="overview-declined-changes-required">
     {% for item in profile.profileData.supportDeclined.circumstanceChangesRequiredToWork %}
-      <div>{{ contentLookup.fields.whatNeedsToChange[item] }}{{ ' - ' +  profile.profileData.supportDeclined.circumstanceChangesRequiredToWorkOther if item === 'OTHER' }}{{ ',' if profile.profileData.supportDeclined.circumstanceChangesRequiredToWork.length !== loop.index }}</div>
+      <div>{{ contentLookup.fields.whatNeedsToChange[item] }}{{ (' - ' +  profile.profileData.supportDeclined.circumstanceChangesRequiredToWorkOther if item === 'OTHER') | safe }}{{ ',' if profile.profileData.supportDeclined.circumstanceChangesRequiredToWork.length !== loop.index }}</div>
     {% endfor %}
   </dd>
   <dd class="govuk-summary-list__actions">

--- a/server/views/pages/workProfile/partials/_workExperienceSection.njk
+++ b/server/views/pages/workProfile/partials/_workExperienceSection.njk
@@ -28,7 +28,7 @@
         </dt>
         <dd class="govuk-summary-list__value" data-qa="experience-qualifications">
           {% for item in  profile.profileData.supportAccepted.workExperience.qualificationsAndTraining %}
-            <div>{{ contentLookup.fields.trainingAndQualifications[item] }}{{ ' - ' +  (profile.profileData.supportAccepted.workExperience.qualificationsAndTrainingOther | safe ) if item === 'OTHER' }}{{ ',' if profile.profileData.supportAccepted.workExperience.qualificationsAndTraining.length !== loop.index }}</div>
+            <div>{{ contentLookup.fields.trainingAndQualifications[item] }}{{ (' - ' +  profile.profileData.supportAccepted.workExperience.qualificationsAndTrainingOther if item === 'OTHER') | safe }}{{ ',' if profile.profileData.supportAccepted.workExperience.qualificationsAndTraining.length !== loop.index }}</div>
           {% endfor %}
         </dd>
         <dd class="govuk-summary-list__actions">

--- a/server/views/pages/workProfile/partials/_workExperienceSection.njk
+++ b/server/views/pages/workProfile/partials/_workExperienceSection.njk
@@ -28,7 +28,7 @@
         </dt>
         <dd class="govuk-summary-list__value" data-qa="experience-qualifications">
           {% for item in  profile.profileData.supportAccepted.workExperience.qualificationsAndTraining %}
-            <div>{{ contentLookup.fields.trainingAndQualifications[item] }}{{ ' - ' +  profile.profileData.supportAccepted.workExperience.qualificationsAndTrainingOther if item === 'OTHER' }}{{ ',' if profile.profileData.supportAccepted.workExperience.qualificationsAndTraining.length !== loop.index }}</div>
+            <div>{{ contentLookup.fields.trainingAndQualifications[item] }}{{ ' - ' +  (profile.profileData.supportAccepted.workExperience.qualificationsAndTrainingOther | safe ) if item === 'OTHER' }}{{ ',' if profile.profileData.supportAccepted.workExperience.qualificationsAndTraining.length !== loop.index }}</div>
           {% endfor %}
         </dd>
         <dd class="govuk-summary-list__actions">

--- a/server/views/pages/workProfile/partials/_workInterestsSection.njk
+++ b/server/views/pages/workProfile/partials/_workInterestsSection.njk
@@ -14,7 +14,7 @@
           </dt>
           <dd class="govuk-summary-list__value" data-qa="interests-type-of-work">
             {% for item in profile.profileData.supportAccepted.workInterests.workTypesOfInterest %}
-              <div>{{ contentLookup.fields.typeOfWork[item] }}{{ ' - ' +  profile.profileData.supportAccepted.workInterests.workTypesOfInterestOther if item === 'OTHER' }}{{ ',' if profile.profileData.supportAccepted.workInterests.workTypesOfInterest.length !== loop.index }}</div>
+              <div>{{ contentLookup.fields.typeOfWork[item] }}{{ ' - ' +  (profile.profileData.supportAccepted.workInterests.workTypesOfInterestOther | safe) if item === 'OTHER' }}{{ ',' if profile.profileData.supportAccepted.workInterests.workTypesOfInterest.length !== loop.index }}</div>
             {% endfor %}
           </dd>
           <dd class="govuk-summary-list__actions" id="interests-type-of-work-link">

--- a/server/views/pages/workProfile/partials/_workInterestsSection.njk
+++ b/server/views/pages/workProfile/partials/_workInterestsSection.njk
@@ -14,7 +14,7 @@
           </dt>
           <dd class="govuk-summary-list__value" data-qa="interests-type-of-work">
             {% for item in profile.profileData.supportAccepted.workInterests.workTypesOfInterest %}
-              <div>{{ contentLookup.fields.typeOfWork[item] }}{{ ' - ' +  (profile.profileData.supportAccepted.workInterests.workTypesOfInterestOther | safe) if item === 'OTHER' }}{{ ',' if profile.profileData.supportAccepted.workInterests.workTypesOfInterest.length !== loop.index }}</div>
+              <div>{{ contentLookup.fields.typeOfWork[item] }}{{ (' - ' +  profile.profileData.supportAccepted.workInterests.workTypesOfInterestOther if item === 'OTHER') | safe }}{{ ',' if profile.profileData.supportAccepted.workInterests.workTypesOfInterest.length !== loop.index }}</div>
             {% endfor %}
           </dd>
           <dd class="govuk-summary-list__actions" id="interests-type-of-work-link">

--- a/server/views/pages/workReadiness/createProfile/checkYourAnswers/partials/_alreadyInPlace.njk
+++ b/server/views/pages/workReadiness/createProfile/checkYourAnswers/partials/_alreadyInPlace.njk
@@ -24,7 +24,7 @@
       </dt>
       <dd class="govuk-summary-list__value" data-qa="identification">
         {% for item in record.identification %}
-          <div>{{ contentLookup.fields.identification[item] }}{{ ' - ' + (record.typeOfIdentificationDetails | safe) if item === 'OTHER' }}{{ ',' if record.identification.length !== loop.index }}</div>
+          <div>{{ contentLookup.fields.identification[item] }}{{ (' - ' + record.typeOfIdentificationDetails if item === 'OTHER' | safe) }}{{ ',' if record.identification.length !== loop.index }}</div>
         {% endfor %}
       </dd>
       <dd class="govuk-summary-list__actions">

--- a/server/views/pages/workReadiness/createProfile/checkYourAnswers/partials/_eligibilityForSupport.njk
+++ b/server/views/pages/workReadiness/createProfile/checkYourAnswers/partials/_eligibilityForSupport.njk
@@ -37,7 +37,7 @@
       </dt>
       <dd class="govuk-summary-list__value" data-qa="supportDeclinedReason">
         {% for item in record.supportDeclinedReason %}
-          <div>{{ contentLookup.fields.supportDeclinedReason[item] }}{{ ' - ' + (record.supportDeclinedDetails | safe) if item === 'OTHER' }}{{ ',' if record.supportDeclinedReason.length !== loop.index }}</div>
+          <div>{{ contentLookup.fields.supportDeclinedReason[item] }}{{ (' - ' + record.supportDeclinedDetails if item === 'OTHER') | safe }}{{ ',' if record.supportDeclinedReason.length !== loop.index }}</div>
         {% endfor %}
       </dd>
       <dd class="govuk-summary-list__actions">
@@ -53,7 +53,7 @@
       </dt>
       <dd class="govuk-summary-list__value" data-qa="whatNeedsToChange">
         {% for item in record.whatNeedsToChange %}
-          <div>{{ contentLookup.fields.whatNeedsToChange[item] }}{{ ' - ' + (record.whatNeedsToChangeDetails | safe) if item === 'OTHER' }}{{ ',' if record.whatNeedsToChange.length !== loop.index }}</div>
+          <div>{{ contentLookup.fields.whatNeedsToChange[item] }}{{ (' - ' + record.whatNeedsToChangeDetails if item === 'OTHER') | safe }}{{ ',' if record.whatNeedsToChange.length !== loop.index }}</div>
         {% endfor %}
       </dd>
       <dd class="govuk-summary-list__actions">

--- a/server/views/pages/workReadiness/createProfile/checkYourAnswers/partials/_workRelatedInfo.njk
+++ b/server/views/pages/workReadiness/createProfile/checkYourAnswers/partials/_workRelatedInfo.njk
@@ -7,7 +7,7 @@
     </dt>
     <dd class="govuk-summary-list__value" data-qa="typeOfWork">
       {% for item in record.typeOfWork %}
-        <div>{{ contentLookup.fields.typeOfWork[item] }}{{ ' - ' + record.typeOfWorkDetails if item === 'OTHER' }}{{ ',' if record.typeOfWork.length !== loop.index }}</div>
+        <div>{{ contentLookup.fields.typeOfWork[item] }}{{ (' - ' + record.typeOfWorkDetails if item === 'OTHER') | safe }}{{ ',' if record.typeOfWork.length !== loop.index }}</div>
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">

--- a/server/views/pages/workReadiness/createProfile/checkYourAnswers/partials/_workRelatedInfo.njk
+++ b/server/views/pages/workReadiness/createProfile/checkYourAnswers/partials/_workRelatedInfo.njk
@@ -48,7 +48,7 @@
     </dt>
     <dd class="govuk-summary-list__value" data-qa="trainingAndQualifications">
       {% for item in record.trainingAndQualifications %}
-        <div>{{ contentLookup.fields.trainingAndQualifications[item] }}{{ ' - ' + (record.trainingAndQualificationsDetails | safe) if item === 'OTHER' }}{{ ',' if record.trainingAndQualifications.length !== loop.index }}</div>
+        <div>{{ contentLookup.fields.trainingAndQualifications[item] }}{{ (' - ' + record.trainingAndQualificationsDetails if item === 'OTHER') | safe }}{{ ',' if record.trainingAndQualifications.length !== loop.index }}</div>
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">


### PR DESCRIPTION
Mark strings as 'safe' to avoid double-escaping special characters when displaying user-inputted free-form text.  

Free-form text is escaped when received as input, and then nunjucks will escape it again by default when rendering the page, causing the special characters to display incorrectly.  Marking them as 'safe' avoids the second escaping step.