### PR TITLE
fix trivy scan error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11243,10 +11243,11 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.4.tgz",
+      "integrity": "sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "typescript": "^5.8.3"
   },
   "overrides": {
+    "tmp": "0.2.4",
     "cypress": {
       "@cypress/request": "^3.0.0"
     },


### PR DESCRIPTION
Output:
║                                    === npm audit security report ===                                                                                                                
║                                                                                                                                                                                                               
║ ID             │ Module │ Paths           │ Severity        │ URL                                                                                                                      
║ 1106849 │ tmp        │ tmp             │ low                 │ https://github.com/advisories/GHSA-52f5-9888-hmc6                                