### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1587,15 +1587,15 @@
       "license": "MIT"
     },
     "node_modules/@ministryofjustice/frontend": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-5.1.5.tgz",
-      "integrity": "sha512-qplsAEv1+8FeMxrBh+Z9NznX4LjZBTRBZubMlUqWKntBasssz5mp7rF/C8VeiuJhMtfOgB3YYDvxoahSQaoKGw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-5.1.0.tgz",
+      "integrity": "sha512-rgvKBJcloW+Uzn7bEAjPMhyUUpxWWFGU58vQsj8Cm6c63fk0gm8UCYVYl0C97W5jgbSWv7gK2+tIQDdHzG1Hcg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       },
       "peerDependencies": {
-        "govuk-frontend": "^5.8.0",
+        "govuk-frontend": "5.9.0",
         "moment": "2.30.1"
       }
     },


### PR DESCRIPTION
Fix npm error Invalid: lock file's @ministryofjustice/frontend@5.1.5 does not satisfy @ministryofjustice/frontend@5.1.0