### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7295,9 +7295,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.11.2.tgz",
-      "integrity": "sha512-eHV8EMxYNjc+omFhB0HktQ3QmA3ZRdDsgRDlUIik+TpUHerR3XKXpo4zh/OGO2/C2mz65cX0XT0k4QrRFJZU8Q==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.9.0.tgz",
+      "integrity": "sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"


### PR DESCRIPTION
Fix npm error Invalid: lock file's govuk-frontend@5.11.2 does not satisfy govuk-frontend@5.9.0