### PR TITLE
ESWE-1455: fix missing prisonid and 12weeks flag

### DIFF
--- a/server/routes/workReadiness/changeStatus/newStatus/newStatusController.ts
+++ b/server/routes/workReadiness/changeStatus/newStatus/newStatusController.ts
@@ -85,8 +85,8 @@ export default class NewStatusController {
       }
 
       // Indicate whether releaseDate is within 12 weeks or not
-      profile.profileData.within12Weeks = isWithin12Weeks(prisoner.nonDtoReleaseDate)
-      profile.profileData.prisonId = prisoner.prisonId
+      profile.profileData.within12Weeks = isWithin12Weeks(data.prisoner.nonDtoReleaseDate)
+      profile.profileData.prisonId = data.prisoner.prisonId
 
       // Status only change
       if (this.isStatusOnlyChange(newStatus, profile.profileData.status, profile)) {

--- a/server/routes/workReadiness/createProfile/supportDeclinedReason/supportDeclinedReasonController.test.ts
+++ b/server/routes/workReadiness/createProfile/supportDeclinedReason/supportDeclinedReasonController.test.ts
@@ -34,9 +34,13 @@ describe('SupportDeclinedReasonController', () => {
   const pageTitleLookupMock = pageTitleLookup as jest.Mock
   pageTitleLookupMock.mockReturnValue('mock_page_title')
 
+  const today = new Date()
+  const formatDate = (date: Date) => date.toISOString().split('T')[0]
+
   req.context.prisoner = {
     firstName: 'mock_firstName',
     lastName: 'mock_lastName',
+    nonDtoReleaseDate: formatDate(today),
   }
 
   req.params.id = 'mock_ref'
@@ -140,6 +144,11 @@ describe('SupportDeclinedReasonController', () => {
       req.body.supportDeclinedReason = SupportDeclinedReasonValue.OTHER
       req.params.mode = 'new'
 
+      req.context.profile = {
+        profileData: {
+          isWithin12Weeks: false,
+        },
+      }
       controller.post(req, res, next)
 
       expect(getSessionData(req, ['createProfile', id])).toEqual({

--- a/server/routes/workReadiness/createProfile/supportDeclinedReason/supportDeclinedReasonController.ts
+++ b/server/routes/workReadiness/createProfile/supportDeclinedReason/supportDeclinedReasonController.ts
@@ -11,6 +11,7 @@ import PrisonerViewModel from '../../../../viewModels/prisonerViewModel'
 import PrisonerProfileService from '../../../../services/prisonerProfileService'
 import UpdateProfileRequest from '../../../../data/models/updateProfileRequest'
 import pageTitleLookup from '../../../../utils/pageTitleLookup'
+import isWithin12Weeks from '../../../../utils/isWithin12Weeks'
 
 export default class SupportDeclinedReasonController {
   constructor(private readonly prisonerProfileService: PrisonerProfileService) {}
@@ -83,6 +84,10 @@ export default class SupportDeclinedReasonController {
       }
 
       deleteSessionData(req, ['supportDeclinedReason', id, 'data'])
+
+      // Indicate whether releaseDate is within 12 weeks and store prisonId
+      profile.profileData.within12Weeks = isWithin12Weeks(data.prisoner.nonDtoReleaseDate)
+      profile.profileData.prisonId = data.prisoner.prisonId
 
       // Handle update
       if (mode === 'update') {

--- a/server/routes/workReadiness/createProfile/whatNeedsToChange/whatNeedsToChangeController.test.ts
+++ b/server/routes/workReadiness/createProfile/whatNeedsToChange/whatNeedsToChangeController.test.ts
@@ -111,6 +111,12 @@ describe('SupportDeclinedReasonController', () => {
       validationMock.mockReset()
       setSessionData(req, ['whatNeedsToChange', id, 'data'], mockData)
       setSessionData(req, ['createProfile', id], {})
+
+      req.context.profile = {
+        profileData: {
+          isWithin12Weeks: false,
+        },
+      }
     })
 
     it('On error - Calls next with error', async () => {

--- a/server/routes/workReadiness/createProfile/whatNeedsToChange/whatNeedsToChangeController.ts
+++ b/server/routes/workReadiness/createProfile/whatNeedsToChange/whatNeedsToChangeController.ts
@@ -11,6 +11,7 @@ import getBackLocation from '../../../../utils/getBackLocation'
 import UpdateProfileRequest from '../../../../data/models/updateProfileRequest'
 import PrisonerProfileService from '../../../../services/prisonerProfileService'
 import pageTitleLookup from '../../../../utils/pageTitleLookup'
+import isWithin12Weeks from '../../../../utils/isWithin12Weeks'
 
 export default class SupportDeclinedReasonController {
   constructor(private readonly prisonerProfileService: PrisonerProfileService) {}
@@ -83,6 +84,10 @@ export default class SupportDeclinedReasonController {
       }
 
       deleteSessionData(req, ['whatNeedsToChange', id, 'data'])
+
+      // Indicate whether releaseDate is within 12 weeks and store prisonId
+      profile.profileData.within12Weeks = isWithin12Weeks(data.prisoner.nonDtoReleaseDate)
+      profile.profileData.prisonId = data.prisoner.prisonId
 
       // Handle update
       if (mode === 'update') {


### PR DESCRIPTION
This PR fixes the problem _"...several frontend controllers are not correctly passing required data, leading to potential inconsistencies in profile updates and status changes."_

Affected controllers

- whatNeedsToChangeController.ts
- supportDeclinedReasonController.ts
- newStatusController.ts