### PR TITLE
EWSE-969: Add service account names for preprod and prod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -2,6 +2,7 @@
 # Per environment values which override defaults in hmpps-education-employment-ui/values.yaml
 
 generic-service:
+  serviceAccountName: education-skills-and-work-live-preprod
   replicaCount: 2
 
   ingress:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -2,6 +2,7 @@
 # Per environment values which override defaults in hmpps-education-employment-ui/values.yaml
 
 generic-service:
+  serviceAccountName: education-skills-and-work-live-production
 
   ingress:
     host: get-ready-for-work.hmpps.service.justice.gov.uk


### PR DESCRIPTION
Service accounts on MJMA are of format `[team name]-[environment]` so we need seperate config for all environments