### PR TITLE
ESWE-1417: missing prisonID on records despite schema update from 1st Aug

### DIFF
--- a/server/data/models/editProfileRequest.ts
+++ b/server/data/models/editProfileRequest.ts
@@ -18,7 +18,7 @@ export default class EditProfileRequest {
       status: data.status,
       prisonName: data.prisonName,
       prisonId: data.prisonId,
-      within12Weeks: existingProfile.profileData.within12Weeks,
+      within12Weeks: data.within12Weeks,
       supportDeclined: this.buildSupportDeclined(data),
       supportAccepted: this.buildSupportAccepted(data, existingProfile),
     }

--- a/server/routes/workReadiness/changeStatus/newStatus/newStatusController.ts
+++ b/server/routes/workReadiness/changeStatus/newStatus/newStatusController.ts
@@ -101,6 +101,7 @@ export default class NewStatusController {
               status: newStatus,
               currentUser: res.locals.user.username,
               prisonId: prisoner.prisonId,
+              within12Weeks: profile.profileData.within12Weeks,
             },
             profile,
           ),


### PR DESCRIPTION

This PR fixes two distinct issues:

- Schema version not updated – resulting in missing prisonID
- Schema version updated correctly – but prisonID is still missing

It also ensures the flag indicating whether release date is within 12 weeks is set properly whenever status changes.