### PR TITLE
ESWE-1846: update text to read save note

### DIFF
--- a/integration_tests/e2e/workReadiness/editAction.cy.ts
+++ b/integration_tests/e2e/workReadiness/editAction.cy.ts
@@ -65,6 +65,8 @@ context('SignIn', () => {
     const editActionPage = new EditActionPage('Bank account')
     editActionPage.addNoteLink().click()
 
+    editActionPage.addNoteButton().should('be.visible').and('contain.text', 'Save note')
+    editActionPage.saveProgressButton().should('be.visible').and('contain.text', 'Save progress')
     editActionPage.addNoteButton().click()
 
     editActionPage.pageErrorMessage().contains('Add or cancel your note before trying to save progress')

--- a/integration_tests/pages/workReadiness/editAction.ts
+++ b/integration_tests/pages/workReadiness/editAction.ts
@@ -17,6 +17,8 @@ export default class EditActionPage extends Page {
 
   addNoteButton = (): PageElement => cy.get('[data-qa=add-note-button]')
 
+  saveProgressButton = (): PageElement => cy.get('[data-qa=submit-button]')
+
   pageErrorMessage = (): PageElement => cy.get('[href="#noteText"]')
 
   fieldErrorMessage = (): PageElement => cy.get('#noteText-error')

--- a/server/views/pages/workReadiness/actions/editAction/index.njk
+++ b/server/views/pages/workReadiness/actions/editAction/index.njk
@@ -132,7 +132,7 @@
         {% include './partials/_notes.njk' %}
 
         {{ govukButton({
-            text: "Save Progress",
+            text: "Save progress",
             type: "submit",
             attributes: {"data-qa": "submit-button", "data-ga-category": "submit-selected-data"}
           }) }}

--- a/server/views/pages/workReadiness/actions/editAction/partials/_notes.njk
+++ b/server/views/pages/workReadiness/actions/editAction/partials/_notes.njk
@@ -41,7 +41,7 @@
   
   <div class="govuk-button-group">
     {{ govukButton({
-      text: "Add note",
+      text: "Save note",
       type: "submit",
       name: "saveNote",
       attributes: {"data-qa": "add-note-button" },


### PR DESCRIPTION
This PR:

**UI changes:**

* Renamed the "Add note" button to "Save note" in the `_notes.njk` partial to better reflect its function.
* Changed the "Save Progress" button label to "Save progress" for consistency in `editAction/index.njk`.

**Test and page object updates:**

* Updated the `EditActionPage` page object to include a new selector for the "Save progress" button.
* Enhanced the end-to-end test to check that both the "Save note" and "Save progress" buttons are visible and have the correct text before interacting with them.