### PR TITLE
ESWE-1876: Update text for 'no results' message in matched jobs tab

### DIFF
--- a/server/views/pages/candidateMatching/matchedJobs/partials/_notFoundMessages.njk
+++ b/server/views/pages/candidateMatching/matchedJobs/partials/_notFoundMessages.njk
@@ -1,8 +1,9 @@
 {% if matchedJobsResults.page.totalElements === 0 %}
-  {% if jobSectorFilter.length %}
-    <span class="govuk-heading-m">0 results in 
-      {% for typeOfWork in jobSectorFilter %}
-        <span>{{ contentLookup.fields.typeOfWork[typeOfWork] }}{{ ',' if loop.index !== jobSectorFilter.length }} </span>
+  {% if jobSectorFilter.length or jobSectorFilterOther.length %}
+    {% set filteredTypesOfWork = jobSectorFilter.concat(jobSectorFilterOther) %}
+    <span class="govuk-heading-m">0 results in
+      {% for typeOfWork in filteredTypesOfWork %}
+        <span>{{ contentLookup.fields.typeOfWork[typeOfWork] }}{% if not loop.last %}, {% endif %}</span>
       {% endfor %}
     </span>
   {% else %}


### PR DESCRIPTION
Update text when no results are returned so that it lists all types of work selected in both ‘types of work interested in’ and ‘other types of work’