### PR TITLE
ESWE-1870: Fix incorrect width of background panel on homepage

### DIFF
--- a/assets/sass/components/_card.scss
+++ b/assets/sass/components/_card.scss
@@ -134,7 +134,7 @@
 
 //from manage supervisions
 .app-card {
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("black", $variant: "tint-95");
   display: block;
   padding: govuk-spacing(2);
   text-decoration: none;
@@ -153,5 +153,5 @@
 
 .app-card--grey {
   color: govuk-shade(govuk-colour("black"), 30);
-  background: govuk-tint(govuk-colour("dark-grey"), 90);
+  background: govuk-tint(govuk-colour("black", $variant: "tint-25"), 90);
 }

--- a/assets/sass/components/_summary-card.scss
+++ b/assets/sass/components/_summary-card.scss
@@ -4,7 +4,7 @@
   /* Card header */
   .app-summary-card__header {
     align-items: center;
-    background-color: govuk-colour("light-grey");
+    background-color: govuk-colour("black", $variant: "tint-95");
     padding: govuk-spacing(3);
 
     @include govuk-media-query($from: desktop) {

--- a/server/views/pages/homePage/index.njk
+++ b/server/views/pages/homePage/index.njk
@@ -6,7 +6,7 @@
 
 {% set title = 'Work after leaving prison' %}
 
-{% block main %}
+{% block container %}
     <main id="main-content" role="main" {%- if mainLang %} lang="{{ mainLang }}"{% endif %}>
         <div class="govuk-grid-row">
             <div class="govuk-width-container">


### PR DESCRIPTION
Fix container width on homepage, and remove use of deprecated light-grey and dark-grey colours

Fixed version:
<img width="1885" height="810" alt="image" src="https://github.com/user-attachments/assets/59e077e7-41a2-45dc-ba6b-f24e56d74d3e" />

Bugged version:
<img width="1814" height="815" alt="image" src="https://github.com/user-attachments/assets/9aed321a-ed23-469b-bb7c-c5b6d380a404" />
