### PR TITLE
ESWE-2023: Added styling fix from template to setUpWebSecurity.ts

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -37,6 +37,7 @@ export default function setUpWebSecurity(): Router {
           ],
           styleSrc: ["'self'", 'code.jquery.com', (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
           formAction: [`'self' ${config.apis.hmppsAuth.externalUrl}`],
+          ...(config.production ? {} : { upgradeInsecureRequests: null }),
           connectSrc: ['*.google-analytics.com', '*.googletagmanager.com', '*.analytics.google.com'],
           objectSrc: ["'none'"], // Disallow <object> or <embed> tags
         },


### PR DESCRIPTION
Added 'Don't force upgrade connections to HTTPS unless in production' from template:
https://github.com/ministryofjustice/hmpps-template-typescript/commit/12d00890dd59031da045ba6cfe74509cd7cb2028 to prevent incorrect styling showing when working locally using Safari
