### PR TITLE
ESWE-1988: Bug fix for 404 not found showing for readiness profiles with status not started

### DIFF
--- a/server/middleware/checkPrisonerProfileViewCriteria.test.ts
+++ b/server/middleware/checkPrisonerProfileViewCriteria.test.ts
@@ -19,6 +19,7 @@ describe('checkPrisonerInActiveCaseLoad middleware', () => {
       locals: {
         userActiveCaseLoad: { caseLoadId: 'MDI' },
         username: 'username',
+        user: { token: 'mock-token' },
         ...(overrides?.locals ?? {}),
       },
       status: statusMock,
@@ -268,7 +269,7 @@ describe('checkPrisonerInActiveCaseLoad middleware', () => {
     prisonerProfileService.getProfileById.mockResolvedValue(profileByIdResult)
 
     const req = makeReq('A1234BC', 'mjma')
-    const res = makeRes()
+    const res = makeRes({ locals: { user: { token: 'mock-token' } } })
     const next: NextFunction = jest.fn()
     await middleware(req, res, next)
 
@@ -312,7 +313,7 @@ describe('checkPrisonerInActiveCaseLoad middleware', () => {
     prisonerProfileService.getProfileById.mockResolvedValue(profileByIdResult)
 
     const req = makeReq('A1234BC')
-    const res = makeRes({ locals: { originalUrl: '/mjma/prisoner/A1234BC/profile' } })
+    const res = makeRes({ locals: { originalUrl: '/mjma/prisoner/A1234BC/profile', user: { token: 'mock-token' } } })
     const next: NextFunction = jest.fn()
     await middleware(req, res, next)
 

--- a/server/middleware/checkPrisonerProfileViewCriteria.ts
+++ b/server/middleware/checkPrisonerProfileViewCriteria.ts
@@ -8,7 +8,12 @@ const MODULE_REDIRECTS: Record<string, string> = {
   unknown: '/',
 }
 
-const MJMA_ALLOWED_PROFILE_STATUSES = ['READY_TO_WORK', 'SUPPORT_NEEDED'] as const
+const MJMA_ALLOWED_PROFILE_STATUSES = [
+  'READY_TO_WORK',
+  'SUPPORT_NEEDED',
+  'SUPPORT_DECLINED',
+  'NO_RIGHT_TO_WORK',
+] as const
 
 const MJMA_CONTEXT_VALUE = 'mjma'
 
@@ -39,7 +44,7 @@ const checkPrisonerProfileViewCriteria =
           .render('notFoundPage.njk', { continueUrl: getContinueUrl(resolveModule(isMjmaContext, module)) })
         return
       }
-      if (isMjmaContext) {
+      try {
         const { profileData } = await prisonerProfileService.getProfileById(user.token, id)
 
         if (!MJMA_ALLOWED_PROFILE_STATUSES.includes(profileData?.status)) {
@@ -48,6 +53,15 @@ const checkPrisonerProfileViewCriteria =
             .render('notFoundPage.njk', { continueUrl: getContinueUrl(resolveModule(isMjmaContext, module)) })
           return
         }
+      } catch (err) {
+        if (
+          err?.data?.status === 404 &&
+          err?.data?.userMessage?.indexOf(`Readiness profile does not exist for offender ${id}`) > -1
+        ) {
+          res.redirect(`/wr/profile/create/${id}/right-to-work/new`)
+          return
+        }
+        throw err
       }
     } catch (err) {
       res.status(404).render('notFoundPage.njk', {

--- a/server/middleware/checkPrisonerProfileViewCriteria.ts
+++ b/server/middleware/checkPrisonerProfileViewCriteria.ts
@@ -8,12 +8,7 @@ const MODULE_REDIRECTS: Record<string, string> = {
   unknown: '/',
 }
 
-const MJMA_ALLOWED_PROFILE_STATUSES = [
-  'READY_TO_WORK',
-  'SUPPORT_NEEDED',
-  'SUPPORT_DECLINED',
-  'NO_RIGHT_TO_WORK',
-] as const
+const MJMA_ALLOWED_PROFILE_STATUSES = ['SUPPORT_DECLINED', 'NO_RIGHT_TO_WORK'] as const
 
 const MJMA_CONTEXT_VALUE = 'mjma'
 
@@ -44,25 +39,20 @@ const checkPrisonerProfileViewCriteria =
           .render('notFoundPage.njk', { continueUrl: getContinueUrl(resolveModule(isMjmaContext, module)) })
         return
       }
-      try {
-        const { profileData } = await prisonerProfileService.getProfileById(user.token, id)
-
-        if (!MJMA_ALLOWED_PROFILE_STATUSES.includes(profileData?.status)) {
-          res
-            .status(404)
-            .render('notFoundPage.njk', { continueUrl: getContinueUrl(resolveModule(isMjmaContext, module)) })
-          return
+      if (isMjmaContext)
+        try {
+          const { profileData } = await prisonerProfileService.getProfileById(user.token, id)
+          if (!MJMA_ALLOWED_PROFILE_STATUSES.includes(profileData?.status)) {
+            res
+              .status(404)
+              .render('notFoundPage.njk', { continueUrl: getContinueUrl(resolveModule(isMjmaContext, module)) })
+            return
+          }
+        } catch (err) {
+          res.status(404).render('notFoundPage.njk', {
+            continueUrl: getContinueUrl(resolveModule(isMjmaContext, module)),
+          })
         }
-      } catch (err) {
-        if (
-          err?.data?.status === 404 &&
-          err?.data?.userMessage?.indexOf(`Readiness profile does not exist for offender ${id}`) > -1
-        ) {
-          res.redirect(`/wr/profile/create/${id}/right-to-work/new`)
-          return
-        }
-        throw err
-      }
     } catch (err) {
       res.status(404).render('notFoundPage.njk', {
         continueUrl: getContinueUrl(resolveModule(isMjmaContext, module)),

--- a/server/middleware/resolvers/getProfileByIdResolver.test.ts
+++ b/server/middleware/resolvers/getProfileByIdResolver.test.ts
@@ -34,11 +34,24 @@ describe('getProfileByIdResolver', () => {
     expect(next).toHaveBeenCalledWith(error)
   })
 
+  it('On error - 404 error - Calls next without error', async () => {
+    serviceMock.getProfileById.mockRejectedValue({
+      data: {
+        status: 404,
+        userMessage: `Readiness profile does not exist for offender ${req.id}`,
+      },
+    })
+
+    await resolver(req, res, next)
+
+    expect(next).toHaveBeenCalledWith()
+  })
+
   it('On error - 400 error - Calls next without error', async () => {
     serviceMock.getProfileById.mockRejectedValue({
       data: {
         status: 400,
-        userMessage: 'Readiness profile does not exist',
+        userMessage: `Readiness profile does not exist for offender ${req.id}`,
       },
     })
 

--- a/server/middleware/resolvers/getProfileByIdResolver.ts
+++ b/server/middleware/resolvers/getProfileByIdResolver.ts
@@ -66,8 +66,11 @@ const getProfileByIdResolver =
 
       next()
     } catch (err) {
-      // Handle no profile
-      if (err?.data?.status === 400 && err?.data?.userMessage.indexOf('Readiness profile does not exist') > -1) {
+      // Handle no profile - accept both 400 and 404
+      if (
+        (err?.data?.status === 400 || err?.data?.status === 404) &&
+        err?.data?.userMessage?.includes('Readiness profile does not exist')
+      ) {
         next()
         return
       }


### PR DESCRIPTION
In checkPrisonerProfileViewCriteria: 

- Moved getProfileById() call outside of isMjmaContext boolean check so runs for all routes (wr as well as mjma)

- Added try-catch block to handle error status 404 with user message 'Readiness profile does not exist for offender ${id}'

- Added a redirect when that error occurs to take user to create/right-to-work page

- Other errors caught via catch block

- Updated test file for checkPrisonerProfileViewCriteria to add mock user.token to stop breaking tests

